### PR TITLE
chore(devcontainer): modernize config for current VS Code + agentic workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,8 @@
         "editor.codeActionsOnSave": {
           "source.fixAll.eslint": "explicit"
         },
-        "js/ts.preferences.importModuleSpecifier": "relative"
+        "javascript.preferences.importModuleSpecifier": "relative",
+        "typescript.preferences.importModuleSpecifier": "relative"
       }
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "Podr Service Development",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24-bookworm",
   "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
@@ -22,12 +23,16 @@
         "ms-azuretools.vscode-docker",
         "redhat.vscode-yaml",
         "ms-vscode.vscode-json",
-        "cloudflare.cloudflare-workers-bindings-extension"
+        "cloudflare.cloudflare-workers-bindings-extension",
+        "github.vscode-pull-request-github"
       ],
       "settings": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true,
-        "typescript.preferences.importModuleSpecifier": "relative"
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "js/ts.preferences.importModuleSpecifier": "relative"
       }
     }
   },


### PR DESCRIPTION
This follows the recent devcontainer modernization pattern merged in your other repos.\n\n### What changed\n- migrates deprecated TypeScript-specific VS Code settings to current js/ts keys\n- adds explicit ESLint code-actions-on-save behavior\n- updates/standardizes devcontainer base and feature defaults for current workflows\n- adds GitHub PR extension where missing\n\n### Why\nKeeps Codespaces/devcontainers aligned with current VS Code schema and avoids deprecated settings drift.