### PR TITLE
chore(deps): ignore typescript major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,16 @@ updates:
       include: "scope"
     open-pull-requests-limit: 5
     versioning-strategy: increase
+    ignore:
+      # typescript-eslint hard-errors on TS 7.0 ("typescript-eslint does not
+      # support TS 7.0"), and 8.65.0 declares a peer range of >=4.8.4 <6.1.0,
+      # so a TS 7 major breaks `bun run lint` outright. Landed once in #666,
+      # reverted in #672, re-proposed in #676. Drop this ignore once
+      # typescript-eslint ships TS 7 support:
+      # https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     groups:
       # Group all dev dependencies together to reduce PRs
       dev-dependencies:


### PR DESCRIPTION
Adds an `ignore` condition to `.github/dependabot.yml` so dependabot stops proposing TypeScript major upgrades.

## Why

`typescript-eslint` hard-errors on TypeScript 7.0:

```
typescript-eslint does not support TS 7.0.
Error: typescript-eslint does not support TS 7.0.
    at Object.<anonymous> (node_modules/typescript-eslint/dist/index.js:52:11)
```

`typescript-eslint@8.65.0` declares a peer range of `typescript: ">=4.8.4 <6.1.0"`, so 7.x is out of range and `bun run lint` fails outright — not a lockfile problem.

This has cycled three times: #666 landed `typescript@7.0.2`, #672 reverted it to `6.0.3`, and #676 re-proposed it.

## Why config rather than closing the PR

Closing a dependabot PR without merging only suppresses that exact version — dependabot's own reply on #676 says it "will get in touch when a new version is available," so 7.0.3 would open a fresh PR.

The comment-command route (the dependabot "ignore this major version" command) did not work here either. The comment posted on #676 was stored with extra characters injected into the bot mention, so dependabot never parsed it as a command and instead replied with its ordinary close-without-merge message. That failure mode is visible in the comment as rendered on #676.

Worth noting the existing `dev-dependencies` group already lists `typescript`, but only for `minor` and `patch` update-types — majors escape the group and open their own PR, which is the mechanism behind the three-way cycle above. An explicit `ignore` condition is the durable fix, and it is version-controlled rather than living in PR-comment state.

## Changes

- `.github/dependabot.yml`: `ignore` condition on `typescript` for `version-update:semver-major`, with a comment recording why and when to remove it.

Minor and patch TypeScript updates continue to flow through the `dev-dependencies` group. No other ecosystem or group is affected.

## Verification

- `.github/dependabot.yml` parses as valid YAML; both the `dev-dependencies` and `cloudflare` groups and both ecosystems (`npm`, `github-actions`) confirmed intact after the edit.
- `Lint, Test & Build` green on this branch.

## Removing this

Drop the `ignore` block once typescript-eslint ships TS 7 support — tracked in typescript-eslint/typescript-eslint#10940, targeting TS >=7.1.