### PR TITLE
ci: auto-sync bun.lock on dependabot PRs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,6 +24,7 @@ concurrency:
 
 # COGS optimizations:
 # - Single job (dependency-review merged) saves runner startup overhead
+#   (sync-lockfile is a second job, but it only runs on Dependabot PRs)
 # - Path filters skip CI for docs/config-only changes
 # - Concurrency cancels superseded runs
 # - timeout-minutes caps runaway jobs
@@ -31,14 +32,76 @@ concurrency:
 # - bun cache via setup-bun
 
 jobs:
+  # Dependabot updates package.json but routinely leaves bun.lock untouched, which
+  # fails `bun install --frozen-lockfile` in both this workflow and deploy.yml -- so
+  # a package.json-only bump breaks the production deploy once merged, not just CI.
+  # This has been patched by hand repeatedly (#668, #670, #677, #680); regenerate the
+  # lockfile and push it to the PR branch instead.
+  #
+  # Kept as a separate job so `contents: write` is scoped to the lockfile push and
+  # never granted to the job that runs lint/test. The install here uses
+  # --ignore-scripts so no dependency lifecycle script executes while a write-capable
+  # token is present; lockfile resolution does not need them.
+  sync-lockfile:
+    name: Sync bun.lock
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    outputs:
+      # SHA the ci job should test: the synced commit when one was pushed,
+      # otherwise empty so checkout falls back to its default ref.
+      sha: ${{ steps.sync.outputs.sha }}
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v7
+      with:
+        # Check out the branch itself, not the merge commit, so the regenerated
+        # lockfile can be pushed back to the PR.
+        ref: ${{ github.head_ref }}
+        sparse-checkout: |
+          package.json
+          bun.lock
+          bunfig.toml
+        sparse-checkout-cone-mode: false
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ env.BUN_VERSION }}
+
+    - name: Regenerate and push bun.lock
+      id: sync
+      run: |
+        bun install --ignore-scripts
+        if git diff --quiet -- bun.lock; then
+          echo "bun.lock already matches package.json, nothing to push"
+          exit 0
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add bun.lock
+        git commit -m "chore: sync bun.lock with dependency update"
+        git push origin HEAD:"$HEAD_REF"
+        echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        echo "Pushed regenerated bun.lock to $HEAD_REF"
+      env:
+        HEAD_REF: ${{ github.head_ref }}
+
   ci:
     name: Lint, Test & Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Waits for sync-lockfile so it tests the synced lockfile, but still runs when
+    # that job is skipped (every non-Dependabot PR).
+    needs: [sync-lockfile]
+    if: ${{ !cancelled() && needs.sync-lockfile.result != 'failure' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
       with:
+        ref: ${{ needs.sync-lockfile.outputs.sha }}
         sparse-checkout: |
           src
           __tests__

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -101,7 +101,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
       with:
-        ref: ${{ needs.sync-lockfile.outputs.sha }}
+        # The synced commit when sync-lockfile pushed one, otherwise the SHA that
+        # triggered this run. github.sha is already the merge commit on
+        # pull_request, so the fallback keeps testing the merge with main rather
+        # than the branch head, and pins an exact commit instead of a moving ref.
+        ref: ${{ needs.sync-lockfile.outputs.sha || github.sha }}
         sparse-checkout: |
           src
           __tests__

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -51,7 +51,7 @@ jobs:
       contents: write
     outputs:
       # SHA the ci job should test: the synced commit when one was pushed,
-      # otherwise empty so checkout falls back to its default ref.
+      # otherwise empty, and the ci job falls back to github.sha.
       sha: ${{ steps.sync.outputs.sha }}
     steps:
     - name: Checkout PR branch


### PR DESCRIPTION
Makes CI regenerate `bun.lock` on Dependabot PRs and push it to the PR branch, so the frozen-lockfile failure stops needing a manual fix.

## The problem

Dependabot updates `package.json` but routinely leaves `bun.lock` untouched, so the install step fails:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

This is not just a CI annoyance. `deploy.yml` runs the same `bun install --frozen-lockfile`, so a `package.json`-only bump that reaches `main` breaks the **production deploy**, not only the PR check.

It has been patched by hand four times already: #668, #670, #677, #680.

## Why not fix it in Dependabot config

Dependabot does support the text `bun.lock` file in the `npm_and_yarn` ecosystem, and the `enable-beta-ecosystems` opt-in that used to gate Bun support is no longer in use — so there is no flag to turn on. In this repo it syncs the lockfile only intermittently: walking the last 40 `chore(deps)` commits, most touch `package.json` alone, and the ones that do include a lockfile are mostly the manual sync commits listed above. Since the behaviour isn't controllable from config, this fixes it repo-side.

## Approach

A separate `sync-lockfile` job, gated to Dependabot-authored PRs, that regenerates the lockfile and pushes it to the PR branch. The `ci` job then takes the synced SHA as its checkout ref via a job output, falling back to the default ref when the sync job is skipped — so the run that fixes the lockfile is also the run that reports on it.

Two deliberate choices:

- **Separate job, not folded into `ci`.** This scopes `contents: write` to the lockfile push and never grants it to the job that runs lint/test.
- **`bun install --ignore-scripts` in the sync job.** No dependency lifecycle script executes while a write-capable token is present; lockfile resolution doesn't need them. The `ci` job's install is unchanged.

## Verification

Simulated a Dependabot-style `package.json`-only bump locally and walked the whole chain:

| Step | Result |
| --- | --- |
| `bun install --frozen-lockfile` with stale lockfile | fails, as CI does today |
| `bun install --ignore-scripts` | regenerates `bun.lock` |
| `git diff --quiet -- bun.lock` | detects the change, would commit and push |
| `bun install --frozen-lockfile` on the result | passes, so the `ci` job's install succeeds |
| no-op path (lockfile already in sync) | no change, push skipped, empty SHA output |

Workflow YAML parses; job graph, conditions, permissions and the checkout ref wiring confirmed.

## Known limitation

The push uses `GITHUB_TOKEN`, and pushes made with it do not trigger new workflow runs. The lockfile gets fixed and this run reports green, but the check is attached to the pre-sync commit — the PR's new head commit will not have its own CI run. Merging is unaffected (checks aren't required to merge here) and the lockfile on `main` is correct either way, which is what protects the deploy.

If you'd rather the PR end up green on its head commit, the fix is to push with a PAT or GitHub App token stored as a **Dependabot** secret (Dependabot-triggered runs can't read Actions secrets) — a one-line change to the checkout/push credentials in the sync job. Left out here to avoid introducing a long-lived token without your say.

---
_Generated by [Claude Code](https://claude.ai/code/session_014FiBMvZmeG8totqp9Ez5FA)_